### PR TITLE
Made index.js compatible with the Mattermost API V4

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,18 @@ module.exports = Franz => class Mattermost extends Franz {
   async validateUrl(url) {
     const baseUrl = new window.URL(url);
     try {
-      const resp = await window.fetch(`${baseUrl.origin}/api/v3/users/initial_load`, {
+      window.fetch(`${baseUrl.origin}/api/v4/system/ping`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-        },
+      }})
+      .then(function(resp){
+         return resp.json();     
+      })
+      .then(function(json){
+        status = json.status;
       });
-      const data = await resp.json();
-
-      return Object.hasOwnProperty.call(data, 'client_cfg');
+      return status == "OK";
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
The V3 API of Mattermost will be deprecated in the next major Mattermost release, and can be manually disabled in Mattermost 4 already. As such, this needs to be upgraded. Besides updating it to the new API version, I changed the call from (the no longer existing) ``/users/initial_load``, to ``/system/ping``. As far as I could tell the original call wasn't used besides checking if it existed and contained a basic value, but contained a lot of not that useful information in the return call.  The ``/system/ping`` call should return the current status of the server better, and contains few information beyond that, making it slightly faster.