### PR TITLE
Use APIv4 to check for status of server

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = Franz => class Mattermost extends Franz {
   async validateUrl(url) {
     const baseUrl = new window.URL(url);
     try {
-      const resp = await window.fetch(`${baseUrl.origin}/api/v3/users/initial_load`, {
+      const resp = await window.fetch(`${baseUrl.origin}/api/v4/system/ping`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -10,7 +10,7 @@ module.exports = Franz => class Mattermost extends Franz {
       });
       const data = await resp.json();
 
-      return Object.hasOwnProperty.call(data, 'client_cfg');
+      return Object.hasOwnProperty.call(data, 'status');
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
APIv3 has been deprecated since january.

This move to the new API version and only do a basic status check on the server.