### PR TITLE
Fix notification bubble when being in multiple teams

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -2,8 +2,10 @@ module.exports = (Franz) => {
   const getMessages = function getMessages() {
     const directMessages = document.querySelectorAll('.sidebar--left .has-badge .badge').length;
     const allMessages = document.querySelectorAll('.sidebar--left .has-badge').length - directMessages;
+    const teamDirectMessages = document.querySelectorAll('.team-wrapper .team-container .badge').length;
+    const teamMessages = document.querySelectorAll('.team-wrapper .unread').length - teamDirectMessages;
 
-    Franz.setBadge(directMessages, allMessages);
+    Franz.setBadge(directMessages + teamDirectMessages, allMessages + teamMessages);
   };
 
   Franz.loop(getMessages);


### PR DESCRIPTION
It is possible to join multiple teams on the same Mattermost server.
Once one joins another team, Mattermost will show add a team sidebar.
When the user selected a different team, Mattermost shows the
notifications for other teams in this sidebar. To propagate the counter
to Franz we also need to extract the number of notifications for
different teams.

Those screenshot show the behavior **before** this change: ~~I wasn't able to test it because I could not figure our how to locally patch the recipe, but the selectors work as expected.~~

<img width="133" alt="screenshot 2019-02-23 11 18 47" src="https://user-images.githubusercontent.com/20943/53285092-cd284c80-375c-11e9-8ab8-60044882b561.png">
<img width="132" alt="screenshot 2019-02-23 11 19 49" src="https://user-images.githubusercontent.com/20943/53285095-f0eb9280-375c-11e9-98e9-83c0751ed375.png">

And **after**:

<img width="135" alt="screenshot 2019-02-23 11 28 37" src="https://user-images.githubusercontent.com/20943/53285191-2ba1fa80-375e-11e9-8421-579bbb9ec98a.png">
<img width="132" alt="screenshot 2019-02-23 11 29 07" src="https://user-images.githubusercontent.com/20943/53285201-3eb4ca80-375e-11e9-88a9-cefca95b60fc.png">
