### PR TITLE
Fix badge for unread channels when in single team

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,11 +1,13 @@
-module.exports = (Franz) => {
+"use strict";
+
+module.exports = Franz => {
   const getMessages = function getMessages() {
     const directMessages = document.querySelectorAll('.sidebar--left .has-badge .badge').length;
     const allMessages = document.querySelectorAll('.sidebar--left .has-badge').length - directMessages;
+    const channelMessages = document.querySelectorAll('.sidebar--left .unread-title').length - allMessages;
     const teamDirectMessages = document.querySelectorAll('.team-wrapper .team-container .badge').length;
     const teamMessages = document.querySelectorAll('.team-wrapper .unread').length - teamDirectMessages;
-
-    Franz.setBadge(directMessages + teamDirectMessages, allMessages + teamMessages);
+    Franz.setBadge(directMessages + teamDirectMessages, allMessages + channelMessages + teamMessages);
   };
 
   Franz.loop(getMessages);

--- a/webview.js
+++ b/webview.js
@@ -1,5 +1,3 @@
-"use strict";
-
 module.exports = Franz => {
   const getMessages = function getMessages() {
     const directMessages = document.querySelectorAll('.sidebar--left .has-badge .badge').length;


### PR DESCRIPTION
Hey,

The unread notification badge was not shown in mattermost, when you only have unread channels. This seams to happen, when you are in a single team and there is no team-switcher visible. 

With my simple change there is now a unread notification badge :-)